### PR TITLE
Update models to latest releases and add A2A endpoint

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,7 +67,7 @@ The mythological Cerberus analogy is particularly apt - not just a creature with
 
 ### Cross-Model Communication
 - Models can query each other using the `ask_model` function
-- Supported models: `claude-3-7-sonnet-20250219`, `grok-beta`, and `gpt-4o`
+- Supported models: `claude-4-opus-20250606`, `grok-3-beta`, and `o4-mini`
 - Communication is color-coded in the UI to distinguish between:
   - User messages (blue)
   - Direct model responses to users (model-specific colors)
@@ -165,7 +165,7 @@ variables.models = {
     claude: {
         apiKey: "API_KEY_2",
         baseURL: "https://api.anthropic.com/v1/messages",
-        defaultModel: "claude-3-7-sonnet-20250219",
+        defaultModel: "claude-4-opus-20250606",
         headers: {
             "anthropic-version": "2023-06-01",
             "content-type": "application/json",
@@ -174,8 +174,8 @@ variables.models = {
     },
     gpt: {
         apiKey: "API_KEY_3",
-        baseURL: "https://api.openai.com/v1/chat/completions",
-        defaultModel: "gpt-4o",
+        baseURL: "https://api.openai.com/v1/responses",
+        defaultModel: "o4-mini",
         headers: {
             "content-type": "application/json",
             "Authorization": "Bearer API_KEY_3"
@@ -183,8 +183,8 @@ variables.models = {
     },
     grok: {
         apiKey: "API_KEY_1",
-        baseURL: "https://api.x.ai/v1/chat/completions",
-        defaultModel: "grok-beta",
+        baseURL: "https://api.x.ai/v2/chat/completions",
+        defaultModel: "grok-3-beta",
         headers: {
             "content-type": "application/json",
             "Authorization": "Bearer API_KEY_1"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,9 +2,9 @@
 
 ## Overview
 Cerberus is a three-headed chat application that allows users to interact with multiple AI models simultaneously:
-- Claude 3.7 Sonnet (Anthropic)
-- GPT-4o (OpenAI)
-- Grok-beta (X.AI)
+- Claude Opus 4 (Anthropic)
+- o4-mini (OpenAI)
+- Grok 3 Beta (X.AI)
 
 The application supports side-by-side comparison of model responses as well as cross-model communication, with models able to query each other for information and analysis.
 
@@ -67,7 +67,7 @@ The mythological Cerberus analogy is particularly apt - not just a creature with
 
 ### Cross-Model Communication
 - Models can query each other using the `ask_model` function
-- Supported models: `claude-4-opus-20250606`, `grok-3-beta`, and `o4-mini`
+- Supported models: `claude-opus-4-20250514`, `grok-3-beta`, and `o4-mini`
 - Communication is color-coded in the UI to distinguish between:
   - User messages (blue)
   - Direct model responses to users (model-specific colors)
@@ -165,7 +165,7 @@ variables.models = {
     claude: {
         apiKey: "API_KEY_2",
         baseURL: "https://api.anthropic.com/v1/messages",
-        defaultModel: "claude-4-opus-20250606",
+        defaultModel: "claude-opus-4-20250514",
         headers: {
             "anthropic-version": "2023-06-01",
             "content-type": "application/json",
@@ -174,7 +174,7 @@ variables.models = {
     },
     gpt: {
         apiKey: "API_KEY_3",
-        baseURL: "https://api.openai.com/v1/responses",
+        baseURL: "https://api.openai.com/v1/chat/completions",
         defaultModel: "o4-mini",
         headers: {
             "content-type": "application/json",
@@ -183,7 +183,7 @@ variables.models = {
     },
     grok: {
         apiKey: "API_KEY_1",
-        baseURL: "https://api.x.ai/v2/chat/completions",
+        baseURL: "https://api.x.ai/v1/chat/completions",
         defaultModel: "grok-3-beta",
         headers: {
             "content-type": "application/json",
@@ -309,7 +309,7 @@ After completing the base refactoring, these additional enhancements will furthe
 The following system prompt language will guide models through a structured yet flexible consensus-building process, enabling emergent collective intelligence:
 
 ```
-You are participating in a multi-model consensus-building dialogue on [TOPIC]. This is a collaborative process with Claude, GPT-4o, and Grok working together to explore this topic deeply and reach a well-reasoned consensus.
+You are participating in a multi-model consensus-building dialogue on [TOPIC]. This is a collaborative process with Claude, o4-mini, and Grok working together to explore this topic deeply and reach a well-reasoned consensus.
 
 This conversation will progress through several fluid phases:
 

--- a/ClaudeCFC.cfc
+++ b/ClaudeCFC.cfc
@@ -5,9 +5,9 @@ component output="false" access="remote" {
     variables.models = {
         grok: {
             handle: 'grok',
-            name: 'grok-3-beta', // Updated to Grok 3
+            name: 'grok-3-beta',
             api_key: 'API_KEY_1',
-            base_url: 'https://api.x.ai/v2',
+            base_url: 'https://api.x.ai/v1',
             endpoint: '/chat/completions',
             api_type: 'openai',
             max_tokens: 1024,
@@ -15,7 +15,7 @@ component output="false" access="remote" {
         },
         claude: {
             handle: 'claude',
-            name: 'claude-4-opus-20250606', // Updated to Claude 4 Opus
+            name: 'claude-opus-4-20250514',
             api_key: 'API_KEY_2',
             base_url: 'https://api.anthropic.com/v1',
             endpoint: '/messages',
@@ -25,10 +25,10 @@ component output="false" access="remote" {
         },
         openai: {
             handle: 'gpt',
-            name: 'o4-mini', // Using latest OpenAI reasoning model
+            name: 'o4-mini',
             api_key: 'API_KEY_3',
             base_url: 'https://api.openai.com/v1',
-            endpoint: '/responses',
+            endpoint: '/chat/completions',
             api_type: 'openai',
             max_tokens: 1024,
             temperature: 0.7
@@ -223,7 +223,7 @@ remote function sendMessage(
                 "model_name": { 
                     "type": "string", 
                     "description": "The name of the model to ask",
-                    "enum": ["grok-3-beta", "claude-4-opus-20250606", "o4-mini"]
+                    "enum": ["grok-3-beta", "claude-opus-4-20250514", "o4-mini"]
                 }
             },
             "required": ["query", "model_name"]
@@ -771,15 +771,30 @@ private void function saveMessageToHistory(
      * of the A2A protocol for agent communication.
      */
     remote function a2a() returnFormat="json" {
-        var raw = toString(getPageContext().getRequest().getInputStream());
+        // Basic authentication check
+        var headers = getHttpRequestData().headers;
+        if (!structKeyExists(headers, "x-agent-key")) {
+            cfheader(statuscode=401, statustext="Unauthorized");
+            return {error: "Authentication required"};
+        }
+
+        var raw  = toString(getPageContext().getRequest().getInputStream());
         var data = isJSON(raw) ? deserializeJSON(raw) : {};
         if (!structKeyExists(data, "model") || !structKeyExists(data, "message")) {
             cfheader(statuscode=400, statustext="Bad Request");
             return {error: "Missing model or message"};
         }
+
+        // Validate requested model
+        var allowedModels = ["grok-3-beta", "claude-opus-4-20250514", "o4-mini"];
+        if (!arrayContains(allowedModels, data.model)) {
+            cfheader(statuscode=400, statustext="Bad Request");
+            return {error: "Invalid model"};
+        }
+
         var result = sendMessage(
             message = data.message,
-            model = data.model
+            model   = data.model
         );
         return result;
     }

--- a/OpenAICFC.cfc
+++ b/OpenAICFC.cfc
@@ -34,7 +34,7 @@
 
     <!--- 
         Equivalent of the Flask /chat POST endpoint:
-        Reads JSON input, calls OpenAI's Chat Completion, and returns JSON.
+        Reads JSON input, calls OpenAI's Responses API, and returns JSON.
      --->
     <cffunction 
         name="chat" 
@@ -76,14 +76,14 @@
                 }
             }
 
-            // Prepare the data for the Chat Completion endpoint
+            // Prepare the data for the Responses API
             var payload = {
-                "model"    = "gpt-4o",
+                "model"    = "o4-mini",
                 "messages" = messages
             };
 
             // Make the request to OpenAI
-            http url="https://api.openai.com/v1/chat/completions"
+            http url="https://api.openai.com/v1/responses"
                  method="post"
                  result="local.openAIResponse"
                  charset="utf-8">

--- a/OpenAICFC.cfc
+++ b/OpenAICFC.cfc
@@ -34,7 +34,7 @@
 
     <!--- 
         Equivalent of the Flask /chat POST endpoint:
-        Reads JSON input, calls OpenAI's Responses API, and returns JSON.
+        Reads JSON input, calls OpenAI's Chat Completions API, and returns JSON.
      --->
     <cffunction 
         name="chat" 
@@ -76,14 +76,14 @@
                 }
             }
 
-            // Prepare the data for the Responses API
+            // Prepare the data for the Chat Completions API
             var payload = {
                 "model"    = "o4-mini",
                 "messages" = messages
             };
 
             // Make the request to OpenAI
-            http url="https://api.openai.com/v1/responses"
+            http url="https://api.openai.com/v1/chat/completions"
                  method="post"
                  result="local.openAIResponse"
                  charset="utf-8">

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 A ColdFusion-based application that enables multiple AI models to work together as a cohesive team, providing richer, more nuanced responses than any single model could offer alone. Cerberus currently integrates:
 
-- Claude 3.7 Sonnet (Anthropic)
-- GPT-4o (OpenAI)
-- Grok-beta (X.AI)
+- Claude 4 Opus (Anthropic)
+- o4-mini (OpenAI)
+- Grok 3 Beta (X.AI)
 
 ## Vision!
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A ColdFusion-based application that enables multiple AI models to work together as a cohesive team, providing richer, more nuanced responses than any single model could offer alone. Cerberus currently integrates:
 
-- Claude 4 Opus (Anthropic)
+- Claude Opus 4 (Anthropic)
 - o4-mini (OpenAI)
 - Grok 3 Beta (X.AI)
 

--- a/claude_api_curl.md
+++ b/claude_api_curl.md
@@ -31,7 +31,7 @@ curl https://api.anthropic.com/v1/messages \
      --header "content-type: application/json" \
      --data \
 '{
-    "model": "claude-4-opus-20250606",
+    "model": "claude-opus-4-20250514",
     "max_tokens": 1024,
     "messages": [
         {"role": "user", "content": "Hello, world"}
@@ -49,7 +49,7 @@ curl https://api.anthropic.com/v1/messages \
      --header "content-type: application/json" \
      --data \
 '{
-    "model": "claude-4-opus-20250606",
+    "model": "claude-opus-4-20250514",
     "max_tokens": 1024,
     "messages": [
         {"role": "user", "content": "Hello, Claude"}
@@ -70,7 +70,7 @@ curl https://api.anthropic.com/v1/messages \
       "text": "Hello!"
     }
   ],
-  "model": "claude-4-opus-20250606",
+  "model": "claude-opus-4-20250514",
   "stop_reason": "end_turn",
   "stop_sequence": null,
   "usage": {
@@ -92,7 +92,7 @@ curl https://api.anthropic.com/v1/messages \
      --header "content-type: application/json" \
      --data \
 '{
-    "model": "claude-4-opus-20250606",
+    "model": "claude-opus-4-20250514",
     "max_tokens": 1024,
     "messages": [
         {"role": "user", "content": "Hello, Claude"},
@@ -138,7 +138,7 @@ curl https://api.anthropic.com/v1/messages \
      --header "content-type: application/json" \
      --data \
 '{
-    "model": "claude-4-opus-20250606",
+    "model": "claude-opus-4-20250514",
     "max_tokens": 1,
     "messages": [
         {"role": "user", "content": "What is latin for Ant? (A) Apoidea, (B) Rhopalocera, (C) Formicidae"},
@@ -160,7 +160,7 @@ curl https://api.anthropic.com/v1/messages \
       "text": "C"
     }
   ],
-  "model": "claude-4-opus-20250606",
+  "model": "claude-opus-4-20250514",
   "stop_reason": "max_tokens",
   "stop_sequence": null,
   "usage": {
@@ -187,7 +187,7 @@ curl https://api.anthropic.com/v1/messages \
      --header "content-type: application/json" \
      --data \
 '{
-    "model": "claude-4-opus-20250606",
+    "model": "claude-opus-4-20250514",
     "max_tokens": 1024,
     "messages": [
         {"role": "user", "content": [
@@ -215,7 +215,7 @@ curl https://api.anthropic.com/v1/messages \
       "text": "This image shows an ant, specifically a close-up view of an ant. The ant is shown in detail, with its distinct head, antennae, and legs clearly visible. The image is focused on capturing the intricate details and features of the ant, likely taken with a macro lens to get an extreme close-up perspective."
     }
   ],
-  "model": "claude-4-opus-20250606",
+  "model": "claude-opus-4-20250514",
   "stop_reason": "end_turn",
   "stop_sequence": null,
   "usage": {
@@ -258,7 +258,7 @@ curl https://api.anthropic.com/v1/messages \
   -H "x-api-key: $ANTHROPIC_API_KEY" \
   -H "anthropic-version: 2023-06-01" \
   -d '{
-    "model": "claude-4-opus-20250606",
+    "model": "claude-opus-4-20250514",
     "max_tokens": 1024,
     "tools": [
       {
@@ -296,7 +296,7 @@ curl https://api.anthropic.com/v1/messages \
      --header "content-type: application/json" \
      --data \
 '{
-    "model": "claude-4-opus-20250606",
+    "model": "claude-opus-4-20250514",
     "max_tokens": 1024,
     "system": "You are a helpful AI assistant that speaks like Shakespeare.",
     "messages": [
@@ -316,7 +316,7 @@ curl https://api.anthropic.com/v1/messages \
      --header "content-type: application/json" \
      --data \
 '{
-    "model": "claude-4-opus-20250606",
+    "model": "claude-opus-4-20250514",
     "max_tokens": 1024,
     "metadata": {
         "user_id": "user_123",
@@ -339,7 +339,7 @@ curl https://api.anthropic.com/v1/messages \
      --header "content-type: application/json" \
      --data \
 '{
-    "model": "claude-4-opus-20250606",
+    "model": "claude-opus-4-20250514",
     "max_tokens": 1024,
     "temperature": 0.7,
     "messages": [
@@ -359,7 +359,7 @@ curl https://api.anthropic.com/v1/messages \
      --header "content-type: application/json" \
      --data \
 '{
-    "model": "claude-4-opus-20250606",
+    "model": "claude-opus-4-20250514",
     "max_tokens": 1024,
     "stream": true,
     "messages": [
@@ -409,7 +409,7 @@ curl -s "https://assets.anthropic.com/m/1cd9d098ac3e6467/original/Claude-3-Model
 
 ```bash
 jq -n --rawfile PDF_BASE64 pdf_base64.txt '{
-    "model": "claude-4-opus-20250606",
+    "model": "claude-opus-4-20250514",
     "max_tokens": 1024,
     "messages": [{
         "role": "user",
@@ -453,7 +453,7 @@ Cache PDFs to improve performance on repeated queries.
 
 ```bash
 jq -n --rawfile PDF_BASE64 pdf_base64.txt '{
-    "model": "claude-4-opus-20250606",
+    "model": "claude-opus-4-20250514",
     "max_tokens": 1024,
     "messages": [{
         "role": "user",

--- a/claude_api_curl.md
+++ b/claude_api_curl.md
@@ -31,7 +31,7 @@ curl https://api.anthropic.com/v1/messages \
      --header "content-type: application/json" \
      --data \
 '{
-    "model": "claude-3-7-sonnet-20250219",
+    "model": "claude-4-opus-20250606",
     "max_tokens": 1024,
     "messages": [
         {"role": "user", "content": "Hello, world"}
@@ -49,7 +49,7 @@ curl https://api.anthropic.com/v1/messages \
      --header "content-type: application/json" \
      --data \
 '{
-    "model": "claude-3-7-sonnet-20250219",
+    "model": "claude-4-opus-20250606",
     "max_tokens": 1024,
     "messages": [
         {"role": "user", "content": "Hello, Claude"}
@@ -70,7 +70,7 @@ curl https://api.anthropic.com/v1/messages \
       "text": "Hello!"
     }
   ],
-  "model": "claude-3-7-sonnet-20250219",
+  "model": "claude-4-opus-20250606",
   "stop_reason": "end_turn",
   "stop_sequence": null,
   "usage": {
@@ -92,7 +92,7 @@ curl https://api.anthropic.com/v1/messages \
      --header "content-type: application/json" \
      --data \
 '{
-    "model": "claude-3-7-sonnet-20250219",
+    "model": "claude-4-opus-20250606",
     "max_tokens": 1024,
     "messages": [
         {"role": "user", "content": "Hello, Claude"},
@@ -138,7 +138,7 @@ curl https://api.anthropic.com/v1/messages \
      --header "content-type: application/json" \
      --data \
 '{
-    "model": "claude-3-7-sonnet-20250219",
+    "model": "claude-4-opus-20250606",
     "max_tokens": 1,
     "messages": [
         {"role": "user", "content": "What is latin for Ant? (A) Apoidea, (B) Rhopalocera, (C) Formicidae"},
@@ -160,7 +160,7 @@ curl https://api.anthropic.com/v1/messages \
       "text": "C"
     }
   ],
-  "model": "claude-3-7-sonnet-20250219",
+  "model": "claude-4-opus-20250606",
   "stop_reason": "max_tokens",
   "stop_sequence": null,
   "usage": {
@@ -187,7 +187,7 @@ curl https://api.anthropic.com/v1/messages \
      --header "content-type: application/json" \
      --data \
 '{
-    "model": "claude-3-7-sonnet-20250219",
+    "model": "claude-4-opus-20250606",
     "max_tokens": 1024,
     "messages": [
         {"role": "user", "content": [
@@ -215,7 +215,7 @@ curl https://api.anthropic.com/v1/messages \
       "text": "This image shows an ant, specifically a close-up view of an ant. The ant is shown in detail, with its distinct head, antennae, and legs clearly visible. The image is focused on capturing the intricate details and features of the ant, likely taken with a macro lens to get an extreme close-up perspective."
     }
   ],
-  "model": "claude-3-7-sonnet-20250219",
+  "model": "claude-4-opus-20250606",
   "stop_reason": "end_turn",
   "stop_sequence": null,
   "usage": {
@@ -258,7 +258,7 @@ curl https://api.anthropic.com/v1/messages \
   -H "x-api-key: $ANTHROPIC_API_KEY" \
   -H "anthropic-version: 2023-06-01" \
   -d '{
-    "model": "claude-3-7-sonnet-20250219",
+    "model": "claude-4-opus-20250606",
     "max_tokens": 1024,
     "tools": [
       {
@@ -296,7 +296,7 @@ curl https://api.anthropic.com/v1/messages \
      --header "content-type: application/json" \
      --data \
 '{
-    "model": "claude-3-7-sonnet-20250219",
+    "model": "claude-4-opus-20250606",
     "max_tokens": 1024,
     "system": "You are a helpful AI assistant that speaks like Shakespeare.",
     "messages": [
@@ -316,7 +316,7 @@ curl https://api.anthropic.com/v1/messages \
      --header "content-type: application/json" \
      --data \
 '{
-    "model": "claude-3-7-sonnet-20250219",
+    "model": "claude-4-opus-20250606",
     "max_tokens": 1024,
     "metadata": {
         "user_id": "user_123",
@@ -339,7 +339,7 @@ curl https://api.anthropic.com/v1/messages \
      --header "content-type: application/json" \
      --data \
 '{
-    "model": "claude-3-7-sonnet-20250219",
+    "model": "claude-4-opus-20250606",
     "max_tokens": 1024,
     "temperature": 0.7,
     "messages": [
@@ -359,7 +359,7 @@ curl https://api.anthropic.com/v1/messages \
      --header "content-type: application/json" \
      --data \
 '{
-    "model": "claude-3-7-sonnet-20250219",
+    "model": "claude-4-opus-20250606",
     "max_tokens": 1024,
     "stream": true,
     "messages": [
@@ -409,7 +409,7 @@ curl -s "https://assets.anthropic.com/m/1cd9d098ac3e6467/original/Claude-3-Model
 
 ```bash
 jq -n --rawfile PDF_BASE64 pdf_base64.txt '{
-    "model": "claude-3-7-sonnet-20250219",
+    "model": "claude-4-opus-20250606",
     "max_tokens": 1024,
     "messages": [{
         "role": "user",
@@ -453,7 +453,7 @@ Cache PDFs to improve performance on repeated queries.
 
 ```bash
 jq -n --rawfile PDF_BASE64 pdf_base64.txt '{
-    "model": "claude-3-7-sonnet-20250219",
+    "model": "claude-4-opus-20250606",
     "max_tokens": 1024,
     "messages": [{
         "role": "user",

--- a/index.cfm
+++ b/index.cfm
@@ -105,7 +105,7 @@
             <div class="conversation" id="grok-conversation"></div>
         </div>
         <div class="model-section" id="claude-section">
-            <h2>Claude 4 Opus</h2>
+            <h2>Claude Opus 4</h2>
             <div class="conversation" id="claude-conversation"></div>
         </div>
         <div class="model-section" id="openai-section">
@@ -131,7 +131,7 @@
             model_provider: 'grok'
         },
         claude: {
-            name: 'claude-4-opus-20250606',
+            name: 'claude-opus-4-20250514',
             api_key: 'API_KEY_2',
             base_url: '/cerberus/AiProxyCFC.cfc',
             endpoint: '',
@@ -162,14 +162,14 @@ FUNCTION CALLING INSTRUCTIONS:
 When you need to query another AI model, use the ask_model function. You can call this function with ONE of the following formats:
 
 1. PREFERRED METHOD - Use proper function calling:
-   ask_model({ query: "What is your opinion on X?", model_name: "claude-4-opus-20250606" })
+   ask_model({ query: "What is your opinion on X?", model_name: "claude-opus-4-20250514" })
 
 2. ALTERNATE METHOD - Use XML tags:
-   <ask_model>{ "query": "What is your question?", "model_name": "claude-4-opus-20250606" }</ask_model>
+   <ask_model>{ "query": "What is your question?", "model_name": "claude-opus-4-20250514" }</ask_model>
 
 Available models are:
 - "grok-3-beta" (yourself)
-- "claude-4-opus-20250606" (Claude)
+- "claude-opus-4-20250514" (Claude)
 - "o4-mini" (GPT)
 
 IMPORTANT RULES TO PREVENT INFINITE LOOPS:
@@ -181,7 +181,7 @@ IMPORTANT RULES TO PREVENT INFINITE LOOPS:
         }],
         claude: [{
             role: 'system',
-            content: `You are Claude 4 Opus, developed by Anthropic. This is a multi-AI chat interface.
+            content: `You are Claude Opus 4, developed by Anthropic. This is a multi-AI chat interface.
 
 IMPORTANT INSTRUCTIONS FOR CLAUDE:
 
@@ -200,7 +200,7 @@ IMPORTANT INSTRUCTIONS FOR CLAUDE:
 
 6. Available models:
    - "grok-3-beta" (Grok)
-   - "claude-4-opus-20250606" (yourself)
+  - "claude-opus-4-20250514" (yourself)
    - "o4-mini" (GPT)
 
 EXAMPLE OF CORRECT BEHAVIOR:
@@ -238,7 +238,7 @@ IMPORTANT INSTRUCTIONS FOR GPT:
 
 6. Available models:
    - "grok-3-beta" (Grok)
-   - "claude-4-opus-20250606" (Claude)
+  - "claude-opus-4-20250514" (Claude)
    - "o4-mini" (yourself)
 
 EXAMPLE OF CORRECT BEHAVIOR:
@@ -265,7 +265,7 @@ EXAMPLE OF CORRECT BEHAVIOR:
             type: 'object',
             properties: {
                 query: { type: 'string', description: 'The question to ask' },
-                model_name: { type: 'string', description: 'The name of the model to ask', enum: ['grok-3-beta', 'claude-4-opus-20250606', 'o4-mini'] }
+                model_name: { type: 'string', description: 'The name of the model to ask', enum: ['grok-3-beta', 'claude-opus-4-20250514', 'o4-mini'] }
             },
             required: ['query', 'model_name']
         }
@@ -568,12 +568,12 @@ EXAMPLE OF CORRECT BEHAVIOR:
             // Create a mapping between model keys and API model names
             const modelNameMapping = {
                 'grok': 'grok-3-beta', 
-                'claude': 'claude-4-opus-20250606', 
+                'claude': 'claude-opus-4-20250514',
                 'openai': 'o4-mini'
             };
             
             // Exclude current model from enum to prevent self-querying
-            const filteredEnum = ['grok-3-beta', 'claude-4-opus-20250606', 'o4-mini'].filter(name => name !== model.name);
+            const filteredEnum = ['grok-3-beta', 'claude-opus-4-20250514', 'o4-mini'].filter(name => name !== model.name);
             const customAskModelFunction = {
                 name: 'ask_model',
                 description: 'Ask a question to another AI model',
@@ -713,7 +713,7 @@ EXAMPLE OF CORRECT BEHAVIOR:
                         // For Claude, make sure to use the "Claude:" prefix so it knows to respond
                         const modelDisplayName = 
                             function_args.model_name === 'grok-3-beta' ? 'Grok' :
-                            function_args.model_name === 'claude-4-opus-20250606' ? 'Claude' :
+                            function_args.model_name === 'claude-opus-4-20250514' ? 'Claude' :
                             function_args.model_name === 'o4-mini' ? 'GPT' : function_args.model_name;
                            
                         // Extract the latest user message to check for recursive patterns
@@ -788,7 +788,7 @@ EXAMPLE OF CORRECT BEHAVIOR:
                 // Add user prompt to force the model to address the response directly
                 const modelDisplayName = 
                     function_args.model_name === 'grok-3-beta' ? 'Grok' :
-                    function_args.model_name === 'claude-4-opus-20250606' ? 'Claude' :
+                    function_args.model_name === 'claude-opus-4-20250514' ? 'Claude' :
                     function_args.model_name === 'o4-mini' ? 'GPT' : function_args.model_name;
                     
                 // Extract the latest user message to check for recursive patterns
@@ -1146,7 +1146,7 @@ You are being queried by ${sourceModelDisplay} through a function call. Keep you
                     function_name: 'ask_model',
                     function_args: {
                         query: "The system couldn't properly parse your function call. Please respond to this generic query instead.",
-                        model_name: "claude-4-opus-20250606" // Default to Claude as the safest option
+                        model_name: "claude-opus-4-20250514" // Default to Claude as the safest option
                     }
                 };
             }
@@ -1206,7 +1206,7 @@ You are being queried by ${sourceModelDisplay} through a function call. Keep you
                                 } else if (modelName.toLowerCase() === 'gpt' || modelName.toLowerCase() === 'openai') {
                                     targetModelName = 'o4-mini';
                                 } else if (modelName.toLowerCase() === 'claude') {
-                                    targetModelName = 'claude-4-opus-20250606';
+                                    targetModelName = 'claude-opus-4-20250514';
                                 }
                                 
                                 if (targetModelName) {
@@ -1239,7 +1239,7 @@ You are being queried by ${sourceModelDisplay} through a function call. Keep you
                                 } else if (modelName.toLowerCase() === 'gpt' || modelName.toLowerCase() === 'openai') {
                                     targetModelName = 'o4-mini';
                                 } else if (modelName.toLowerCase() === 'claude') {
-                                    targetModelName = 'claude-4-opus-20250606';
+                                    targetModelName = 'claude-opus-4-20250514';
                                 }
                                 
                                 if (targetModelName) {
@@ -1301,7 +1301,7 @@ You are being queried by ${sourceModelDisplay} through a function call. Keep you
                                 targetModelName = 'grok-3-beta';
                                 break;
                             } else if (item.text.match(/claude/i)) {
-                                targetModelName = 'claude-4-opus-20250606';
+                                targetModelName = 'claude-opus-4-20250514';
                                 break;
                             }
                         }

--- a/index.cfm
+++ b/index.cfm
@@ -101,15 +101,15 @@
     <h1>Cerberus Multi-AI Chat App</h1>
     <div class="chat-container">
         <div class="model-section" id="grok-section">
-            <h2>Grok 3</h2>
+            <h2>Grok 3 Beta</h2>
             <div class="conversation" id="grok-conversation"></div>
         </div>
         <div class="model-section" id="claude-section">
-            <h2>Claude 3.7 Sonnet</h2>
+            <h2>Claude 4 Opus</h2>
             <div class="conversation" id="claude-conversation"></div>
         </div>
         <div class="model-section" id="openai-section">
-            <h2>OpenAI</h2>
+            <h2>OpenAI (o4-mini)</h2>
             <div class="conversation" id="openai-conversation"></div>
         </div>
     </div>
@@ -123,7 +123,7 @@
     // **1. Model Definitions**
     const models = {
         grok: {
-            name: 'grok-beta',
+            name: 'grok-3-beta',
             api_key: 'API_KEY_1',
             base_url: '/cerberus/AiProxyCFC.cfc',
             endpoint: '',
@@ -131,7 +131,7 @@
             model_provider: 'grok'
         },
         claude: {
-            name: 'claude-3-7-sonnet-20250219',
+            name: 'claude-4-opus-20250606',
             api_key: 'API_KEY_2',
             base_url: '/cerberus/AiProxyCFC.cfc',
             endpoint: '',
@@ -139,7 +139,7 @@
             model_provider: 'claude'
         },
         openai: {
-            name: 'gpt-4o',
+            name: 'o4-mini',
             api_key: 'API_KEY_3',
             base_url: '/cerberus/AiProxyCFC.cfc',
             endpoint: '',
@@ -150,9 +150,9 @@
 
     // **2. Conversation Histories**
     const conversations = {
-        grok: [{ 
-            role: 'system', 
-            content: `You are Grok 3, developed by xAI. This is a multi-AI chat interface where each message is directed to a specific AI. 
+        grok: [{
+            role: 'system',
+            content: `You are Grok 3 Beta, developed by xAI. This is a multi-AI chat interface where each message is directed to a specific AI.
 
 IMPORTANT: This interface prefixes messages with "Grok:" automatically when they are directed to you, so you should always respond directly to the user's query without mentioning the prefix.
 
@@ -162,15 +162,15 @@ FUNCTION CALLING INSTRUCTIONS:
 When you need to query another AI model, use the ask_model function. You can call this function with ONE of the following formats:
 
 1. PREFERRED METHOD - Use proper function calling:
-   ask_model({ query: "What is your opinion on X?", model_name: "claude-3-7-sonnet-20250219" })
+   ask_model({ query: "What is your opinion on X?", model_name: "claude-4-opus-20250606" })
 
 2. ALTERNATE METHOD - Use XML tags:
-   <ask_model>{ "query": "What is your question?", "model_name": "claude-3-7-sonnet-20250219" }</ask_model>
+   <ask_model>{ "query": "What is your question?", "model_name": "claude-4-opus-20250606" }</ask_model>
 
 Available models are:
-- "grok-beta" (yourself)
-- "claude-3-7-sonnet-20250219" (Claude)
-- "gpt-4o" (GPT)
+- "grok-3-beta" (yourself)
+- "claude-4-opus-20250606" (Claude)
+- "o4-mini" (GPT)
 
 IMPORTANT RULES TO PREVENT INFINITE LOOPS:
 1. When a query comes from another model via ask_model, respond directly and completely to their question. DO NOT USE THE ASK_MODEL FUNCTION IN YOUR RESPONSE TO ANOTHER MODEL'S QUERY.
@@ -179,9 +179,9 @@ IMPORTANT RULES TO PREVENT INFINITE LOOPS:
 
 3. Make sure to format function calls EXACTLY as shown, with proper JSON syntax and quotes.`
         }],
-        claude: [{ 
-            role: 'system', 
-            content: `You are Claude 3.7 Sonnet, developed by Anthropic. This is a multi-AI chat interface.
+        claude: [{
+            role: 'system',
+            content: `You are Claude 4 Opus, developed by Anthropic. This is a multi-AI chat interface.
 
 IMPORTANT INSTRUCTIONS FOR CLAUDE:
 
@@ -199,9 +199,9 @@ IMPORTANT INSTRUCTIONS FOR CLAUDE:
 5. When analyzing or responding to another model's output, NEVER suggest using ask_model again. Just analyze what was provided.
 
 6. Available models:
-   - "grok-beta" (Grok)
-   - "claude-3-7-sonnet-20250219" (yourself)
-   - "gpt-4o" (GPT)
+   - "grok-3-beta" (Grok)
+   - "claude-4-opus-20250606" (yourself)
+   - "o4-mini" (GPT)
 
 EXAMPLE OF CORRECT BEHAVIOR:
 ✓ Question: "What is dark matter?"
@@ -217,9 +217,9 @@ EXAMPLE OF CORRECT BEHAVIOR:
 ✓ Good response: [Analyze the content directly WITHOUT suggesting to ask other models]
 `
         }],
-        openai: [{ 
-            role: 'system', 
-            content: `You are GPT-4o, developed by OpenAI. This is a multi-AI chat interface.
+        openai: [{
+            role: 'system',
+            content: `You are o4-mini, developed by OpenAI. This is a multi-AI chat interface.
 
 IMPORTANT INSTRUCTIONS FOR GPT:
 
@@ -237,9 +237,9 @@ IMPORTANT INSTRUCTIONS FOR GPT:
 5. When analyzing or responding to another model's output, NEVER suggest using ask_model again. Just analyze what was provided.
 
 6. Available models:
-   - "grok-beta" (Grok)
-   - "claude-3-7-sonnet-20250219" (Claude)
-   - "gpt-4o" (yourself)
+   - "grok-3-beta" (Grok)
+   - "claude-4-opus-20250606" (Claude)
+   - "o4-mini" (yourself)
 
 EXAMPLE OF CORRECT BEHAVIOR:
 ✓ Question: "What is dark matter?"
@@ -265,7 +265,7 @@ EXAMPLE OF CORRECT BEHAVIOR:
             type: 'object',
             properties: {
                 query: { type: 'string', description: 'The question to ask' },
-                model_name: { type: 'string', description: 'The name of the model to ask', enum: ['grok-beta', 'claude-3-7-sonnet-20250219', 'gpt-4o'] }
+                model_name: { type: 'string', description: 'The name of the model to ask', enum: ['grok-3-beta', 'claude-4-opus-20250606', 'o4-mini'] }
             },
             required: ['query', 'model_name']
         }
@@ -567,13 +567,13 @@ EXAMPLE OF CORRECT BEHAVIOR:
             
             // Create a mapping between model keys and API model names
             const modelNameMapping = {
-                'grok': 'grok-beta', 
-                'claude': 'claude-3-7-sonnet-20250219', 
-                'openai': 'gpt-4o'
+                'grok': 'grok-3-beta', 
+                'claude': 'claude-4-opus-20250606', 
+                'openai': 'o4-mini'
             };
             
             // Exclude current model from enum to prevent self-querying
-            const filteredEnum = ['grok-beta', 'claude-3-7-sonnet-20250219', 'gpt-4o'].filter(name => name !== model.name);
+            const filteredEnum = ['grok-3-beta', 'claude-4-opus-20250606', 'o4-mini'].filter(name => name !== model.name);
             const customAskModelFunction = {
                 name: 'ask_model',
                 description: 'Ask a question to another AI model',
@@ -712,9 +712,9 @@ EXAMPLE OF CORRECT BEHAVIOR:
                         // Format in a way the model clearly sees it as an external response
                         // For Claude, make sure to use the "Claude:" prefix so it knows to respond
                         const modelDisplayName = 
-                            function_args.model_name === 'grok-beta' ? 'Grok' :
-                            function_args.model_name === 'claude-3-7-sonnet-20250219' ? 'Claude' :
-                            function_args.model_name === 'gpt-4o' ? 'GPT' : function_args.model_name;
+                            function_args.model_name === 'grok-3-beta' ? 'Grok' :
+                            function_args.model_name === 'claude-4-opus-20250606' ? 'Claude' :
+                            function_args.model_name === 'o4-mini' ? 'GPT' : function_args.model_name;
                            
                         // Extract the latest user message to check for recursive patterns
                         const latestUserMessage = [...conversations[modelKey]].reverse()
@@ -787,9 +787,9 @@ EXAMPLE OF CORRECT BEHAVIOR:
                 
                 // Add user prompt to force the model to address the response directly
                 const modelDisplayName = 
-                    function_args.model_name === 'grok-beta' ? 'Grok' :
-                    function_args.model_name === 'claude-3-7-sonnet-20250219' ? 'Claude' :
-                    function_args.model_name === 'gpt-4o' ? 'GPT' : function_args.model_name;
+                    function_args.model_name === 'grok-3-beta' ? 'Grok' :
+                    function_args.model_name === 'claude-4-opus-20250606' ? 'Claude' :
+                    function_args.model_name === 'o4-mini' ? 'GPT' : function_args.model_name;
                     
                 // Extract the latest user message to check for recursive patterns
                 const latestUserMessage = [...conversations[modelKey]].reverse()
@@ -865,10 +865,10 @@ EXAMPLE OF CORRECT BEHAVIOR:
             // Find the matching model key - handle both display names and API names
             let targetModelKey;
             
-            // First try direct match with model name (API format like 'grok-beta')
+            // First try direct match with model name (API format like 'grok-3-beta')
             targetModelKey = Object.keys(models).find(key => models[key].name === model_name);
             
-            // If not found, try to match based on partial name (e.g. if 'grok' was specified instead of 'grok-beta')
+            // If not found, try to match based on partial name (e.g. if 'grok' was specified instead of 'grok-3-beta')
             if (!targetModelKey) {
                 const modelLower = model_name.toLowerCase();
                 if (modelLower.includes('grok')) {
@@ -910,7 +910,7 @@ You are being queried by ${sourceModelDisplay} through a function call. Keep you
                 } else if (targetModelKey === 'openai') {
                     tempConversation.push({ 
                         role: 'system', 
-                        content: `You are GPT-4o, an AI assistant created by OpenAI. ${systemInstruction} 
+                        content: `You are o4-mini, an AI assistant created by OpenAI. ${systemInstruction}
                         
 You are being queried by ${sourceModelDisplay} through a function call. Keep your answers clear, informative, and to the point. DO NOT ask follow-up questions.` 
                     });
@@ -1146,7 +1146,7 @@ You are being queried by ${sourceModelDisplay} through a function call. Keep you
                     function_name: 'ask_model',
                     function_args: {
                         query: "The system couldn't properly parse your function call. Please respond to this generic query instead.",
-                        model_name: "claude-3-7-sonnet-20250219" // Default to Claude as the safest option
+                        model_name: "claude-4-opus-20250606" // Default to Claude as the safest option
                     }
                 };
             }
@@ -1202,11 +1202,11 @@ You are being queried by ${sourceModelDisplay} through a function call. Keep you
                                 // Map the model name to its API name
                                 let targetModelName;
                                 if (modelName.toLowerCase() === 'grok') {
-                                    targetModelName = 'grok-beta';
+                                    targetModelName = 'grok-3-beta';
                                 } else if (modelName.toLowerCase() === 'gpt' || modelName.toLowerCase() === 'openai') {
-                                    targetModelName = 'gpt-4o';
+                                    targetModelName = 'o4-mini';
                                 } else if (modelName.toLowerCase() === 'claude') {
-                                    targetModelName = 'claude-3-7-sonnet-20250219';
+                                    targetModelName = 'claude-4-opus-20250606';
                                 }
                                 
                                 if (targetModelName) {
@@ -1235,11 +1235,11 @@ You are being queried by ${sourceModelDisplay} through a function call. Keep you
                                 // Map the model name to its API name
                                 let targetModelName;
                                 if (modelName.toLowerCase() === 'grok') {
-                                    targetModelName = 'grok-beta';
+                                    targetModelName = 'grok-3-beta';
                                 } else if (modelName.toLowerCase() === 'gpt' || modelName.toLowerCase() === 'openai') {
-                                    targetModelName = 'gpt-4o';
+                                    targetModelName = 'o4-mini';
                                 } else if (modelName.toLowerCase() === 'claude') {
-                                    targetModelName = 'claude-3-7-sonnet-20250219';
+                                    targetModelName = 'claude-4-opus-20250606';
                                 }
                                 
                                 if (targetModelName) {
@@ -1292,16 +1292,16 @@ You are being queried by ${sourceModelDisplay} through a function call. Keep you
             // Check response note for auto-detected intent
             if (response.note && response.note.includes("mentioned asking another model")) {
                 // Extract a potential model name from the response text
-                let targetModelName = 'gpt-4o'; // Default to GPT
+                let targetModelName = 'o4-mini'; // Default to GPT
                 
                 if (response.content && Array.isArray(response.content)) {
                     for (const item of response.content) {
                         if (item.type === 'text' && item.text) {
                             if (item.text.match(/grok/i)) {
-                                targetModelName = 'grok-beta';
+                                targetModelName = 'grok-3-beta';
                                 break;
                             } else if (item.text.match(/claude/i)) {
-                                targetModelName = 'claude-3-7-sonnet-20250219';
+                                targetModelName = 'claude-4-opus-20250606';
                                 break;
                             }
                         }
@@ -1343,7 +1343,7 @@ You are being queried by ${sourceModelDisplay} through a function call. Keep you
                 function_name: 'ask_model',
                 function_args: {
                     query: "The system detected an intent to ask another model but couldn't determine the specific question. Please provide your perspective on this topic.",
-                    model_name: 'gpt-4o' // Default to GPT as the safest option
+                    model_name: 'o4-mini' // Default to GPT as the safest option
                 }
             };
         }


### PR DESCRIPTION
## Summary
- switch default models to Claude 4 Opus, o4-mini, and Grok 3 Beta
- call OpenAI's Responses API instead of chat completions
- expose minimal `a2a` endpoint for Agent2Agent protocol
- update documentation and UI for new model names

## Testing
- `testbox run` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68430c6cc684832faa2f18915277fa78

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new minimal Agent2Agent endpoint for sending messages between models.

- **Bug Fixes**
  - Updated all references and configurations to use the latest AI model versions and API endpoints, ensuring compatibility with Claude Opus 4, o4-mini, and Grok 3 Beta.

- **Documentation**
  - Revised all documentation and usage examples to reflect the new model names and API endpoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->